### PR TITLE
Fix services pages

### DIFF
--- a/src/components/ServiceNavButton.tsx
+++ b/src/components/ServiceNavButton.tsx
@@ -37,6 +37,14 @@ const StyledTitle = styled.div`
   color: ${Colors.white};
   font-size: 32px;
   font-weight: bold;
+
+  @media (max-width: 991px) {
+    font-size: 24px;
+  }
+
+  @media (max-width: 991px) {
+    font-size: 20px;
+  }
 `;
 
 const StyledText = styled.div`
@@ -44,14 +52,13 @@ const StyledText = styled.div`
   letter-spacing: 0.24em;
 `;
 
-const StyledNextImg = styled.img`
+const StyledNextPrevImg = styled.img`
   margin-top: 17px;
   width: 52px;
-`;
 
-const StyledPreviousImg = styled.img`
-  margin-top: 17px;
-  width: 52px;
+  @media (max-width: 991px) {
+    margin-top: 10px;
+  }
 `;
 
 const StyledPrevImgWrapper = styled.div`
@@ -80,14 +87,14 @@ export const ServiceNavButton = (props: ServiceNavButtonProps) => {
             </StyledNextContent>
           </Col>
           <Col xs={3}>
-            <StyledNextImg src={RightArrow} alt={'right-arrow'} />
+            <StyledNextPrevImg src={RightArrow} alt={'right-arrow'} />
           </Col>
         </Row>
       ) : (
         <Row onClick={handlePreviousClick}>
           <Col xs={3}>
             <StyledPrevImgWrapper>
-              <StyledPreviousImg src={LeftArrow} alt={'left-arrow'} />
+              <StyledNextPrevImg src={LeftArrow} alt={'left-arrow'} />
             </StyledPrevImgWrapper>
           </Col>
           <Col xs={9}>

--- a/src/components/ServiceNavButton.tsx
+++ b/src/components/ServiceNavButton.tsx
@@ -39,10 +39,6 @@ const StyledTitle = styled.div`
   font-weight: bold;
 
   @media (max-width: 991px) {
-    font-size: 24px;
-  }
-
-  @media (max-width: 991px) {
     font-size: 20px;
   }
 `;

--- a/src/pages/AugmentationPage.tsx
+++ b/src/pages/AugmentationPage.tsx
@@ -12,9 +12,9 @@ import { Routes } from 'consts/routes';
 
 const StyledHeader = styled.div`
   background: ${Gradients.green};
-  padding: 0 164px;
+  padding: 80px 164px 0;
 
-  @media (max-width: 767px) {
+  @media (max-width: 991px) {
     padding: 80px 20px 0;
   }
 `;
@@ -23,7 +23,7 @@ const StyledServices = styled.div`
   color: ${Colors.white};
   font-size: 28px;
 
-  @media (max-width: 767px) {
+  @media (max-width: 991px) {
     font-size: 24px;
   }
 `;
@@ -34,8 +34,8 @@ const StyledAugmentation = styled.div`
   font-weight: bold;
   position: relative;
 
-  @media (max-width: 767px) {
-    font-size: 68px;
+  @media (max-width: 991px) {
+    font-size: 55px;
   }
 `;
 
@@ -49,8 +49,8 @@ const StyledAugmentationShadow = styled.div`
   top: 8px;
   left: 8px;
 
-  @media (max-width: 767px) {
-    font-size: 68px;
+  @media (max-width: 991px) {
+    font-size: 55px;
   }
 `;
 
@@ -62,7 +62,7 @@ const StyledContentWrapper = styled.div`
   background-color: ${Colors.black};
   padding: 0 164px 120px 164px;
 
-  @media (max-width: 767px) {
+  @media (max-width: 991px) {
     padding: 0 20px;
   }
 `;
@@ -82,9 +82,13 @@ const StyledHowWeDoWrapper = styled.div`
   padding: 64px 0;
   font-size: 24px;
   letter-spacing: 1.2em;
+
+  @media (max-width: 991px) {
+    letter-spacing: 1em;
+  }
 `;
 
-const StyledHowWeDoPhrase = styled.div`
+const StyledHowWeDo = styled.div`
   color: #5a646b;
   position: relative;
 `;
@@ -96,6 +100,10 @@ const StyledHowWeDoShadow = styled.div`
   position: absolute;
   top: 0px;
   left: 6px;
+
+  @media (max-width: 991px) {
+    letter-spacing: 1em;
+  }
 `;
 
 const StyledServiceAspect = styled(Col)`
@@ -103,8 +111,7 @@ const StyledServiceAspect = styled(Col)`
 `;
 
 const StyledFooterWrapper = styled.div`
-  background-color: #072337;
-  padding-top: 80px;
+  background-color: ${Colors.lightNavy};
 `;
 
 const StyledNavButtonCol = styled(Col)`
@@ -147,14 +154,14 @@ const AugmentationPage = () => {
         </StyledPhrase>
 
         <StyledHowWeDoWrapper>
-          <StyledHowWeDoPhrase>
+          <StyledHowWeDo>
             HOW WE DO
             <StyledHowWeDoShadow>HOW WE DO</StyledHowWeDoShadow>
-          </StyledHowWeDoPhrase>
+          </StyledHowWeDo>
         </StyledHowWeDoWrapper>
 
         <Row>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.purple}
               icon={Elixir}
@@ -164,7 +171,7 @@ const AugmentationPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.pink}
               icon={Ruby}
@@ -174,7 +181,7 @@ const AugmentationPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.lightBlue}
               icon={ReactIcon}

--- a/src/pages/DeliveryPage.tsx
+++ b/src/pages/DeliveryPage.tsx
@@ -15,9 +15,9 @@ import { Routes } from 'consts/routes';
 
 const StyledHeader = styled.div`
   background: ${Gradients.yellow};
-  padding: 0 164px;
+  padding: 80px 164px 0;
 
-  @media (max-width: 767px) {
+  @media (max-width: 991px) {
     padding: 80px 20px 0;
   }
 `;
@@ -26,7 +26,7 @@ const StyledServices = styled.div`
   color: ${Colors.white};
   font-size: 28px;
 
-  @media (max-width: 767px) {
+  @media (max-width: 991px) {
     font-size: 24px;
   }
 `;
@@ -37,8 +37,8 @@ const StyledDelivery = styled.div`
   font-weight: bold;
   position: relative;
 
-  @media (max-width: 767px) {
-    font-size: 68px;
+  @media (max-width: 991px) {
+    font-size: 55px;
   }
 `;
 
@@ -52,8 +52,8 @@ const StyledDeliveryShadow = styled.div`
   top: 8px;
   left: 8px;
 
-  @media (max-width: 767px) {
-    font-size: 68px;
+  @media (max-width: 991px) {
+    font-size: 55px;
   }
 `;
 
@@ -65,7 +65,7 @@ const StyledContentWrapper = styled.div`
   background-color: ${Colors.black};
   padding: 0 164px 120px 164px;
 
-  @media (max-width: 767px) {
+  @media (max-width: 991px) {
     padding: 0 20px;
   }
 `;
@@ -85,9 +85,13 @@ const StyledHowWeDoWrapper = styled.div`
   padding: 64px 0;
   font-size: 24px;
   letter-spacing: 1.2em;
+
+  @media (max-width: 991px) {
+    letter-spacing: 1em;
+  }
 `;
 
-const StyledHowWeDoPhrase = styled.div`
+const StyledHowWeDo = styled.div`
   color: #5a646b;
   position: relative;
 `;
@@ -99,6 +103,10 @@ const StyledHowWeDoShadow = styled.div`
   position: absolute;
   top: 0px;
   left: 6px;
+
+  @media (max-width: 991px) {
+    letter-spacing: 1em;
+  }
 `;
 
 const StyledServiceAspect = styled(Col)`
@@ -106,8 +114,7 @@ const StyledServiceAspect = styled(Col)`
 `;
 
 const StyledFooterWrapper = styled.div`
-  background-color: #072337;
-  padding-top: 80px;
+  background-color: ${Colors.lightNavy};
 `;
 
 const StyledNavButtonCol = styled(Col)`
@@ -147,14 +154,14 @@ const DeliveryPage = () => {
         </StyledPhrase>
 
         <StyledHowWeDoWrapper>
-          <StyledHowWeDoPhrase>
+          <StyledHowWeDo>
             HOW WE DO
             <StyledHowWeDoShadow>HOW WE DO</StyledHowWeDoShadow>
-          </StyledHowWeDoPhrase>
+          </StyledHowWeDo>
         </StyledHowWeDoWrapper>
 
         <Row>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.purple}
               icon={Team}
@@ -164,7 +171,7 @@ const DeliveryPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.yellow}
               icon={Star}
@@ -174,7 +181,7 @@ const DeliveryPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.blue}
               icon={Programming}
@@ -187,7 +194,7 @@ const DeliveryPage = () => {
         </Row>
 
         <Row>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.pink}
               icon={Data}
@@ -197,7 +204,7 @@ const DeliveryPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.lightBlue}
               icon={ReactIcon}
@@ -207,7 +214,7 @@ const DeliveryPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.green}
               icon={PhaseOut}

--- a/src/pages/DeliveryPage.tsx
+++ b/src/pages/DeliveryPage.tsx
@@ -191,9 +191,7 @@ const DeliveryPage = () => {
               }
             />
           </StyledServiceAspect>
-        </Row>
 
-        <Row>
           <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.pink}

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -7,87 +7,94 @@ import styled from 'styled-components';
 import { Footer, ServiceCard } from 'components';
 import { Routes } from 'consts/routes';
 
-const StyledContentWrapper = styled.div`
+const StyledPageWrapper = styled.div`
   padding-top: 80px;
   background-color: ${Colors.black};
+`;
+
+const StyledHeaderCol = styled(Col)`
+  display: flex;
+  align-items: center;
 `;
 
 const StyledHeader = styled.div`
   font-size: 88px;
   font-weight: bold;
   color: ${Colors.white};
-  overflow-x: hidden;
   padding-left: 30px;
+  width: 455px;
 
-  @media (max-width: 767px) {
+  @media (max-width: 1240px) {
+    font-size: 70px;
+    width: 360px;
+  }
+
+  @media (max-width: 991px) {
     font-size: 44px;
     padding: 40px 20px;
+    width: 230px;
   }
 `;
 
-const StyledServiceCards = styled.div`
-  background-color: #031d30;
+const StyledServiceCardsCol = styled(Col)`
+  background-color: ${Colors.navy};
 `;
 
-const StyledCardWrapper = styled.div`
+const StyledCardPadding = styled.div`
   padding: 20px 15px;
 `;
 
 const StyledFooterWrapper = styled.div`
-  background-color: #072337;
+  background-color: ${Colors.lightNavy};
 `;
 
 const Services = () => {
   return (
-    <>
-      <StyledContentWrapper>
-        <Row>
-          <Col xs={12} sm={5} style={{ display: 'flex', alignItems: 'center' }}>
-            <StyledHeader>Trusted by global innovators.</StyledHeader>
-          </Col>
-          <Col xs={12} sm={7}>
-            <StyledServiceCards>
-              <StyledCardWrapper>
-                <ServiceCard
-                  title={'Storming'}
-                  description={
-                    'We help innovators quickly understand how we will build their digital products and provide a competitive business advantage.'
-                  }
-                  strongLastPhrase={'The idea that works.'}
-                  color={Gradients.blue}
-                  url={Routes.storming}
-                />
-              </StyledCardWrapper>
-              <StyledCardWrapper>
-                <ServiceCard
-                  title={'Delivery'}
-                  description={
-                    'We build high-quality digital products that scale. We do that through new technologies, great talents, and true agile methods.'
-                  }
-                  strongLastPhrase={'The product that works.'}
-                  color={Gradients.yellow}
-                  url={Routes.delivery}
-                />
-              </StyledCardWrapper>
-              <StyledCardWrapper>
-                <ServiceCard
-                  title={'Augmentation'}
-                  description={
-                    'We provide staff augmentation to high-growth tech companies using new programming languages to move faster.'
-                  }
-                  strongLastPhrase={'The team that works.'}
-                  color={Gradients.green}
-                  url={Routes.augmentation}
-                />
-              </StyledCardWrapper>
-            </StyledServiceCards>
-          </Col>
-        </Row>
-      </StyledContentWrapper>
+    <StyledPageWrapper>
+      <Row>
+        <StyledHeaderCol md={12} lg={5}>
+          <StyledHeader>Trusted by global innovators.</StyledHeader>
+        </StyledHeaderCol>
+        <StyledServiceCardsCol md={12} lg={7}>
+          <StyledCardPadding>
+            <ServiceCard
+              title={'Storming'}
+              description={
+                'We help innovators quickly understand how we will build their digital products and provide a competitive business advantage.'
+              }
+              strongLastPhrase={'The idea that works.'}
+              color={Gradients.blue}
+              url={Routes.storming}
+            />
+          </StyledCardPadding>
+          <StyledCardPadding>
+            <ServiceCard
+              title={'Delivery'}
+              description={
+                'We build high-quality digital products that scale. We do that through new technologies, great talents, and true agile methods.'
+              }
+              strongLastPhrase={'The product that works.'}
+              color={Gradients.yellow}
+              url={Routes.delivery}
+            />
+          </StyledCardPadding>
+          <StyledCardPadding>
+            <ServiceCard
+              title={'Augmentation'}
+              description={
+                'We provide staff augmentation to high-growth tech companies using new programming languages to move faster.'
+              }
+              strongLastPhrase={'The team that works.'}
+              color={Gradients.green}
+              url={Routes.augmentation}
+            />
+          </StyledCardPadding>
+        </StyledServiceCardsCol>
+      </Row>
       <StyledFooterWrapper>
         <Footer />
       </StyledFooterWrapper>
-    </>
+    </StyledPageWrapper>
   );
 };
 

--- a/src/pages/StormingPage.tsx
+++ b/src/pages/StormingPage.tsx
@@ -18,7 +18,7 @@ const StyledHeader = styled.div`
   background: ${Gradients.lightBlue};
   padding: 80px 164px 0;
 
-  @media (max-width: 767px) {
+  @media (max-width: 991px) {
     padding: 80px 20px 0;
   }
 `;
@@ -27,7 +27,7 @@ const StyledServices = styled.div`
   color: ${Colors.white};
   font-size: 28px;
 
-  @media (max-width: 767px) {
+  @media (max-width: 991px) {
     font-size: 24px;
   }
 `;
@@ -38,8 +38,8 @@ const StyledStorming = styled.div`
   font-weight: bold;
   position: relative;
 
-  @media (max-width: 767px) {
-    font-size: 68px;
+  @media (max-width: 991px) {
+    font-size: 55px;
   }
 `;
 
@@ -53,8 +53,8 @@ const StyledStormingShadow = styled.div`
   top: 8px;
   left: 8px;
 
-  @media (max-width: 767px) {
-    font-size: 68px;
+  @media (max-width: 991px) {
+    font-size: 55px;
   }
 `;
 
@@ -66,7 +66,7 @@ const StyledContentWrapper = styled.div`
   background-color: ${Colors.black};
   padding: 0 164px 120px 164px;
 
-  @media (max-width: 767px) {
+  @media (max-width: 991px) {
     padding: 0 20px;
   }
 `;
@@ -86,9 +86,13 @@ const StyledHowWeDoWrapper = styled.div`
   padding: 64px 0;
   font-size: 24px;
   letter-spacing: 1.2em;
+
+  @media (max-width: 991px) {
+    letter-spacing: 1em;
+  }
 `;
 
-const StyledHowWeDoPhrase = styled.div`
+const StyledHowWeDo = styled.div`
   color: #5a646b;
   position: relative;
 `;
@@ -100,6 +104,10 @@ const StyledHowWeDoShadow = styled.div`
   position: absolute;
   top: 0px;
   left: 6px;
+
+  @media (max-width: 991px) {
+    letter-spacing: 1em;
+  }
 `;
 
 const StyledServiceAspect = styled(Col)`
@@ -107,8 +115,7 @@ const StyledServiceAspect = styled(Col)`
 `;
 
 const StyledFooterWrapper = styled.div`
-  background-color: #072337;
-  padding-top: 80px;
+  background-color: ${Colors.lightNavy};
 `;
 
 const StyledNavButtonCol = styled(Col)`
@@ -148,14 +155,14 @@ const StormingPage = () => {
         </StyledPhrase>
 
         <StyledHowWeDoWrapper>
-          <StyledHowWeDoPhrase>
+          <StyledHowWeDo>
             HOW WE DO
             <StyledHowWeDoShadow>HOW WE DO</StyledHowWeDoShadow>
-          </StyledHowWeDoPhrase>
+          </StyledHowWeDo>
         </StyledHowWeDoWrapper>
 
         <Row>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.purple}
               icon={Benchmark}
@@ -165,7 +172,7 @@ const StormingPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.yellow}
               icon={Inception}
@@ -175,7 +182,7 @@ const StormingPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.blue}
               icon={Roadmap}
@@ -188,7 +195,7 @@ const StormingPage = () => {
         </Row>
 
         <Row>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.pink}
               icon={Architecture}
@@ -198,7 +205,7 @@ const StormingPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.lightBlue}
               icon={Prototype}
@@ -208,7 +215,7 @@ const StormingPage = () => {
               }
             />
           </StyledServiceAspect>
-          <StyledServiceAspect xs={12} sm={6} md={4}>
+          <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.green}
               icon={Validation}

--- a/src/pages/StormingPage.tsx
+++ b/src/pages/StormingPage.tsx
@@ -192,9 +192,7 @@ const StormingPage = () => {
               }
             />
           </StyledServiceAspect>
-        </Row>
 
-        <Row>
           <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.pink}


### PR DESCRIPTION
- Títulos foram colocados para ter largura fixa de modo a não mudar o número de linhas(conforme discutido na call com a designer)
- Mudanças das resoluções para 991px
- Nas telas `Storming`, `Augmentation` e `Delivery` foram alterados para que os cards ficassem em formato 3, 2 e 1 coluna conforma for diminuindo a tela
- Algumas refatorações pequenas para tentar reduzir e melhorar os codigos

![services](https://user-images.githubusercontent.com/43474330/94724995-7966e780-0331-11eb-9527-cf10c90af2b3.gif)
![fix-storming](https://user-images.githubusercontent.com/43474330/94725054-913e6b80-0331-11eb-988b-c7d5cfd20116.gif)

