### PR TITLE
Ajuste detalhes

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -91,10 +91,14 @@ const StyledLink = styled.a`
   }
 `;
 
+const StyledRow = styled(Row)`
+  margin: 0;
+`;
+
 export const Footer = () => {
   return (
     <StyledFooter>
-      <Row>
+      <StyledRow>
         <Col md={12} lg={6}>
           <StyledTextWrapper color={'#546E82'} fontWeight={'bold'}>
             We do digital.
@@ -188,7 +192,7 @@ export const Footer = () => {
             <StyledMap src={WorldMap} alt={'world-map'} />
           </StyledMapWrapper>
         </Col>
-      </Row>
+      </StyledRow>
     </StyledFooter>
   );
 };

--- a/src/components/ServiceNavButton.tsx
+++ b/src/components/ServiceNavButton.tsx
@@ -61,6 +61,10 @@ const StyledPrevImgWrapper = styled.div`
   text-align: right;
 `;
 
+const StyledRow = styled(Row)`
+  margin: 0;
+`;
+
 export const ServiceNavButton = (props: ServiceNavButtonProps) => {
   const history = useHistory();
 
@@ -75,7 +79,7 @@ export const ServiceNavButton = (props: ServiceNavButtonProps) => {
   return (
     <StyledServiceNavButton color={props.color}>
       {props.next ? (
-        <Row onClick={handleNextClick}>
+        <StyledRow onClick={handleNextClick}>
           <Col xs={9}>
             <StyledNextContent>
               <StyledTitle>{props.title}</StyledTitle>
@@ -85,9 +89,9 @@ export const ServiceNavButton = (props: ServiceNavButtonProps) => {
           <Col xs={3}>
             <StyledNextPrevImg src={RightArrow} alt={'right-arrow'} />
           </Col>
-        </Row>
+        </StyledRow>
       ) : (
-        <Row onClick={handlePreviousClick}>
+        <StyledRow onClick={handlePreviousClick}>
           <Col xs={3}>
             <StyledPrevImgWrapper>
               <StyledNextPrevImg src={LeftArrow} alt={'left-arrow'} />
@@ -99,7 +103,7 @@ export const ServiceNavButton = (props: ServiceNavButtonProps) => {
               <StyledText>Previous</StyledText>
             </StyledPreviousContent>
           </Col>
-        </Row>
+        </StyledRow>
       )}
     </StyledServiceNavButton>
   );

--- a/src/components/SliderCard.tsx
+++ b/src/components/SliderCard.tsx
@@ -15,6 +15,12 @@ export const HorizontalScroll = styled.div`
   flex-direction: row;
   overflow: auto;
   white-space: normal;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+
+  ::-webkit-scrollbar {
+    display: none;
+  }
 `;
 
 const MiniCard = styled.div`

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -60,6 +60,7 @@ const StyledHeaderText = styled.div`
 const StyledPhotosRow = styled.div`
   text-align: center;
   display: flex;
+  margin: 0;
 `;
 
 const StyledBoardPostitPhoto = styled.div`
@@ -234,6 +235,10 @@ const StyledVectorRight = styled.img`
   }
 `;
 
+const StyledRow = styled(Row)`
+  margin: 0;
+`;
+
 const AboutUs = () => {
   const handleClick = () => window.open(JOB_OPENING_URL, '_blank');
 
@@ -288,7 +293,7 @@ const AboutUs = () => {
       </StyledPhotosRow>
 
       <StyledContent>
-        <Row center={'xs'} start={'lg'}>
+        <StyledRow center={'xs'} start={'lg'}>
           <Col md={12} lg={6}>
             <StyledContentTitle>Excellence</StyledContentTitle>
             <StyledContentText>
@@ -301,7 +306,7 @@ const AboutUs = () => {
           <Col lg={6} className={'hidden-xs hidden-sm hidden-md'}>
             <AboutUsSlider cardList={ABOUT_US_CARDS_1}></AboutUsSlider>
           </Col>
-        </Row>
+        </StyledRow>
       </StyledContent>
 
       <StyledLargePhotoWrapper>
@@ -309,7 +314,7 @@ const AboutUs = () => {
       </StyledLargePhotoWrapper>
 
       <StyledContent>
-        <Row center={'xs'} start={'lg'}>
+        <StyledRow center={'xs'} start={'lg'}>
           <Col lg={6} className={'hidden-xs hidden-sm hidden-md'}>
             <AboutUsSlider cardList={ABOUT_US_CARDS_2}></AboutUsSlider>
           </Col>
@@ -322,7 +327,7 @@ const AboutUs = () => {
               ambitious goals as important as the results itself.
             </StyledContentText>
           </Col>
-        </Row>
+        </StyledRow>
       </StyledContent>
 
       <StyledLargePhotoWrapper>
@@ -330,7 +335,7 @@ const AboutUs = () => {
       </StyledLargePhotoWrapper>
 
       <StyledContent>
-        <Row center={'xs'} start={'lg'}>
+        <StyledRow center={'xs'} start={'lg'}>
           <Col md={12} lg={6}>
             <StyledContentTitle>Learning</StyledContentTitle>
             <StyledContentText>
@@ -345,7 +350,7 @@ const AboutUs = () => {
           <Col lg={6} className={'hidden-xs hidden-sm hidden-md'}>
             <AboutUsSlider cardList={ABOUT_US_CARDS_3}></AboutUsSlider>
           </Col>
-        </Row>
+        </StyledRow>
       </StyledContent>
 
       <StyledButton onClick={handleClick}>

--- a/src/pages/AboutUs.tsx
+++ b/src/pages/AboutUs.tsx
@@ -139,11 +139,7 @@ const StyledWritingWallPostitZoomed = styled.img`
 `;
 
 const StyledContent = styled.div`
-  margin: 80px 70px;
-
-  @media (max-width: 1700px) {
-    margin: 80px 64px;
-  }
+  margin: 80px 64px;
 
   @media (max-width: 991px) {
     margin: 40px 16px;
@@ -239,6 +235,14 @@ const StyledRow = styled(Row)`
   margin: 0;
 `;
 
+const StyledRightCardCol = styled(Col)`
+  padding-left: 50px;
+`;
+
+const StyledLeftCardCol = styled(Col)`
+  padding-right: 50px;
+`;
+
 const AboutUs = () => {
   const handleClick = () => window.open(JOB_OPENING_URL, '_blank');
 
@@ -303,9 +307,12 @@ const AboutUs = () => {
               genuinely love what they do. When you love what you do, you excel.
             </StyledContentText>
           </Col>
-          <Col lg={6} className={'hidden-xs hidden-sm hidden-md'}>
+          <StyledRightCardCol
+            lg={6}
+            className={'hidden-xs hidden-sm hidden-md'}
+          >
             <AboutUsSlider cardList={ABOUT_US_CARDS_1}></AboutUsSlider>
-          </Col>
+          </StyledRightCardCol>
         </StyledRow>
       </StyledContent>
 
@@ -315,9 +322,9 @@ const AboutUs = () => {
 
       <StyledContent>
         <StyledRow center={'xs'} start={'lg'}>
-          <Col lg={6} className={'hidden-xs hidden-sm hidden-md'}>
+          <StyledLeftCardCol lg={6} className={'hidden-xs hidden-sm hidden-md'}>
             <AboutUsSlider cardList={ABOUT_US_CARDS_2}></AboutUsSlider>
-          </Col>
+          </StyledLeftCardCol>
           <Col md={12} lg={6}>
             <StyledContentTitle>Teamwork</StyledContentTitle>
             <StyledContentText>
@@ -347,9 +354,12 @@ const AboutUs = () => {
               why we need to learn. Fast.
             </StyledContentText>
           </Col>
-          <Col lg={6} className={'hidden-xs hidden-sm hidden-md'}>
+          <StyledRightCardCol
+            lg={6}
+            className={'hidden-xs hidden-sm hidden-md'}
+          >
             <AboutUsSlider cardList={ABOUT_US_CARDS_3}></AboutUsSlider>
-          </Col>
+          </StyledRightCardCol>
         </StyledRow>
       </StyledContent>
 

--- a/src/pages/AugmentationPage.tsx
+++ b/src/pages/AugmentationPage.tsx
@@ -118,7 +118,7 @@ const StyledNavButtonCol = styled(Col)`
   padding: 0;
 `;
 
-const StyledNavButtonRow = styled(Row)`
+const StyledRow = styled(Row)`
   margin: 0;
 `;
 
@@ -126,7 +126,7 @@ const AugmentationPage = () => {
   return (
     <>
       <StyledHeader>
-        <Row bottom={'xs'}>
+        <StyledRow bottom={'xs'}>
           <Col xs={6}>
             <StyledHeaderText>
               <StyledServices>SERVICES</StyledServices>
@@ -141,7 +141,7 @@ const AugmentationPage = () => {
           <Col xs={6}>
             <img src={Augmentation} width={'100%'} alt={'augmentation'} />
           </Col>
-        </Row>
+        </StyledRow>
       </StyledHeader>
       <StyledContentWrapper>
         <StyledPhrase>
@@ -160,7 +160,7 @@ const AugmentationPage = () => {
           </StyledHowWeDo>
         </StyledHowWeDoWrapper>
 
-        <Row>
+        <StyledRow>
           <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.purple}
@@ -191,10 +191,10 @@ const AugmentationPage = () => {
               }
             />
           </StyledServiceAspect>
-        </Row>
+        </StyledRow>
       </StyledContentWrapper>
 
-      <StyledNavButtonRow>
+      <StyledRow>
         <StyledNavButtonCol xs={6}>
           <ServiceNavButton
             title={'Delivery'}
@@ -210,7 +210,7 @@ const AugmentationPage = () => {
             nextServiceUrl={Routes.storming}
           />
         </StyledNavButtonCol>
-      </StyledNavButtonRow>
+      </StyledRow>
 
       <StyledFooterWrapper>
         <Footer />

--- a/src/pages/DeliveryPage.tsx
+++ b/src/pages/DeliveryPage.tsx
@@ -121,7 +121,7 @@ const StyledNavButtonCol = styled(Col)`
   padding: 0;
 `;
 
-const StyledNavButtonRow = styled(Row)`
+const StyledRow = styled(Row)`
   margin: 0;
 `;
 
@@ -129,7 +129,7 @@ const DeliveryPage = () => {
   return (
     <>
       <StyledHeader>
-        <Row bottom={'xs'}>
+        <StyledRow bottom={'xs'}>
           <Col xs={6}>
             <StyledHeaderText>
               <StyledServices>SERVICES</StyledServices>
@@ -142,7 +142,7 @@ const DeliveryPage = () => {
           <Col xs={6}>
             <img src={Delivery} width={'100%'} alt={'delivery'} />
           </Col>
-        </Row>
+        </StyledRow>
       </StyledHeader>
       <StyledContentWrapper>
         <StyledPhrase>
@@ -160,7 +160,7 @@ const DeliveryPage = () => {
           </StyledHowWeDo>
         </StyledHowWeDoWrapper>
 
-        <Row>
+        <StyledRow>
           <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.purple}
@@ -222,10 +222,10 @@ const DeliveryPage = () => {
               }
             />
           </StyledServiceAspect>
-        </Row>
+        </StyledRow>
       </StyledContentWrapper>
 
-      <StyledNavButtonRow>
+      <StyledRow>
         <StyledNavButtonCol xs={6}>
           <ServiceNavButton
             title={'Storming'}
@@ -241,7 +241,7 @@ const DeliveryPage = () => {
             nextServiceUrl={Routes.augmentation}
           />
         </StyledNavButtonCol>
-      </StyledNavButtonRow>
+      </StyledRow>
 
       <StyledFooterWrapper>
         <Footer />

--- a/src/pages/Home.css
+++ b/src/pages/Home.css
@@ -1,8 +1,0 @@
-::-webkit-scrollbar {
-  display: none;
-}
-
-html {
-  -ms-overflow-style: none;
-  scrollbar-width: none;
-}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import './Home.css';
 import { Col, Row } from 'react-flexbox-grid';
 import Storming from 'assets/images/Storming.svg';
 import Delivery from 'assets/images/Delivery.svg';
@@ -97,10 +96,14 @@ const StyledFooter = styled.div`
   background: ${Colors.lightNavy};
 `;
 
+const StyledRow = styled(Row)`
+  margin: 0;
+`;
+
 const Home = () => {
   return (
     <StyledHome>
-      <Row middle={'xs'}>
+      <StyledRow middle={'xs'}>
         <Col xs={4} sm={6}>
           <StyledHeaderTitle>
             Lean digital innovation that works.
@@ -111,7 +114,7 @@ const Home = () => {
             <img src={TypeLogo} alt={''} width={'100%'} />
           </StyledImage>
         </Col>
-      </Row>
+      </StyledRow>
       <HorizontalScroll>
         <StyledLogos>
           <StyledColumn>

--- a/src/pages/HowWeCanHelp.tsx
+++ b/src/pages/HowWeCanHelp.tsx
@@ -9,6 +9,8 @@ import DataPurple from 'assets/icons/DataPurple.svg';
 import Prototype from 'assets/icons/Prototype.svg';
 import Architecture from 'assets/icons/Architecture.svg';
 import VectorRight from 'assets/icons/VectorRight.svg';
+import { useHistory } from 'react-router-dom';
+import { Routes } from 'consts/routes';
 
 const StyledPageWrapper = styled.div`
   background-color: ${Colors.black};
@@ -103,6 +105,10 @@ const StyledRow = styled(Row)`
 `;
 
 const HowWeCanHelp = () => {
+  const history = useHistory();
+
+  const handleClick = () => history.push(Routes.services ?? '');
+
   return (
     <>
       <StyledPageWrapper>
@@ -152,7 +158,7 @@ const HowWeCanHelp = () => {
                   }
                 />
               </StyledAspectWrapper>
-              <StyledButton>
+              <StyledButton onClick={handleClick}>
                 <StyledButtonTitle>Interested?</StyledButtonTitle>
                 <StyledButtonTitle>Meet our process</StyledButtonTitle>
                 <StyledSeeMore>

--- a/src/pages/HowWeCanHelp.tsx
+++ b/src/pages/HowWeCanHelp.tsx
@@ -98,11 +98,15 @@ const StyledVectorRight = styled.img`
   }
 `;
 
+const StyledRow = styled(Row)`
+  margin: 0;
+`;
+
 const HowWeCanHelp = () => {
   return (
     <>
       <StyledPageWrapper>
-        <Row>
+        <StyledRow>
           <StyledHeaderCol md={12} lg={5}>
             <StyledHeader>How we can help</StyledHeader>
           </StyledHeaderCol>
@@ -158,7 +162,7 @@ const HowWeCanHelp = () => {
               </StyledButton>
             </StyledServiceAspects>
           </Col>
-        </Row>
+        </StyledRow>
       </StyledPageWrapper>
       <StyledFooterWrapper>
         <Footer />

--- a/src/pages/Services.tsx
+++ b/src/pages/Services.tsx
@@ -48,10 +48,14 @@ const StyledFooterWrapper = styled.div`
   background-color: ${Colors.lightNavy};
 `;
 
+const StyledRow = styled(Row)`
+  margin: 0;
+`;
+
 const Services = () => {
   return (
     <StyledPageWrapper>
-      <Row>
+      <StyledRow>
         <StyledHeaderCol md={12} lg={5}>
           <StyledHeader>Trusted by global innovators.</StyledHeader>
         </StyledHeaderCol>
@@ -90,7 +94,7 @@ const Services = () => {
             />
           </StyledCardPadding>
         </StyledServiceCardsCol>
-      </Row>
+      </StyledRow>
       <StyledFooterWrapper>
         <Footer />
       </StyledFooterWrapper>

--- a/src/pages/StormingPage.tsx
+++ b/src/pages/StormingPage.tsx
@@ -122,7 +122,7 @@ const StyledNavButtonCol = styled(Col)`
   padding: 0;
 `;
 
-const StyledNavButtonRow = styled(Row)`
+const StyledRow = styled(Row)`
   margin: 0;
 `;
 
@@ -130,7 +130,7 @@ const StormingPage = () => {
   return (
     <>
       <StyledHeader>
-        <Row bottom={'xs'}>
+        <StyledRow bottom={'xs'}>
           <Col xs={6}>
             <StyledHeaderText>
               <StyledServices>SERVICES</StyledServices>
@@ -143,7 +143,7 @@ const StormingPage = () => {
           <Col xs={6}>
             <img src={Storming} width={'100%'} alt={'storming'} />
           </Col>
-        </Row>
+        </StyledRow>
       </StyledHeader>
       <StyledContentWrapper>
         <StyledPhrase>
@@ -161,7 +161,7 @@ const StormingPage = () => {
           </StyledHowWeDo>
         </StyledHowWeDoWrapper>
 
-        <Row>
+        <StyledRow>
           <StyledServiceAspect sm={12} md={6} lg={4}>
             <ServiceAspect
               color={Colors.purple}
@@ -223,10 +223,10 @@ const StormingPage = () => {
               }
             />
           </StyledServiceAspect>
-        </Row>
+        </StyledRow>
       </StyledContentWrapper>
 
-      <StyledNavButtonRow>
+      <StyledRow>
         <StyledNavButtonCol xs={6}>
           <ServiceNavButton
             title={'Augmentation'}
@@ -242,7 +242,7 @@ const StormingPage = () => {
             nextServiceUrl={Routes.delivery}
           />
         </StyledNavButtonCol>
-      </StyledNavButtonRow>
+      </StyledRow>
 
       <StyledFooterWrapper>
         <Footer />


### PR DESCRIPTION
- Ajuste do scroll horizontal que estava ocorrendo por causa das `Row` que veio da lib. Aparentemente ela vem com margens negativas o que acaba causando o scroll em todas as telas. A solução foi colocar `margin: 0` em todas as `Row`.
- Foi adicionado o clique do botão da página de `How We Can help`
- Aumentado o espaçamento entre cards e texto na tela `About us`